### PR TITLE
add contextual ObservableProperty

### DIFF
--- a/linkml/schema/peh.yaml
+++ b/linkml/schema/peh.yaml
@@ -1033,7 +1033,9 @@ slots:
     inlined: false
   dependent_contextual_observable_properties:
     range: ContextualObservableProperty
-    inline: false
+    multivalued: true
+    required: false
+    inlined_as_list: false
   observed_values:
     multivalued: true
     inlined_as_list: true


### PR DESCRIPTION
This class provides a context-specific update to the `ObservableProperties` which themselves should always refer to other `ObservableProperties` with their proper identifier.

Each ContextualObservableProperty refers to a published ObservableProperty. The ObservableProperty will point to a range of other ObservableProperties for validation, ... The ContextualObservableProperties allow us to link these to concrete datasets and data_fields. When each ObservableProperty in a dataset is only used once the dependent_contextual_observabale_properties are not needed. Otherwise this can be used to indicate which ContextualObservableProperties a certain ContextualObservableProperty depends on. Note that this will still break if an ObservableProperty needs to point to multiple concrete instances of the same ObservableProperty. 
Do we need to accommodate for such use cases?
