### PR TITLE
Add suggester slot (prov:wasAttributedTo) to BioChemEntitySubClass

### DIFF
--- a/linkml/schema/peh.yaml
+++ b/linkml/schema/peh.yaml
@@ -3,7 +3,7 @@ name: PEH-Model
 description: |-
   Entity and relation ontology and datamodel for Personal Exposure and Health data
 
-version: 0.6.1
+version: 0.6.2
 
 imports:
   - linkml:types
@@ -166,6 +166,7 @@ classes:
       - is_metabolite_of
       - is_isomer_of
       - parent_biochementities
+      - suggester
   
   Matrix:
     class_uri: wikidata:Q685816
@@ -732,6 +733,12 @@ slots:
     slot_uri: prov:wasDerivedFrom
     range: NamedThing
     domain: NamedThing
+  suggester:
+    slot_uri: prov:wasAttributedTo
+    range: uriorcurie
+    description: >-
+      ORCID of the person who suggested this entity, recorded as the provenance
+      attribution (prov:wasAttributedTo) of the resulting nanopublication.
   orcid:
     slot_uri: schema:identifier
   rorid:


### PR DESCRIPTION
New optional `suggester` slot carries the ORCID of the person who proposed a biochementity term; it maps to prov:wasAttributedTo so the resulting nanopublication can attribute provenance to the suggester. Additive, backward-compatible; bump schema version 0.6.1 -> 0.6.2.